### PR TITLE
Add opt-in AI-Ready badge and GitHub topic (Step 12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **AI-Ready badge** (Step 12) — opt-in Shields.io badge and `ai-ready` GitHub topic offered after the report, linking back to this plugin for discoverability
+
+### Changed
+
+- Contributors row rationale changed from "who to put in CODEOWNERS" to "contribution patterns" — CODEOWNERS is a human reviewer workflow, not an AI-readiness concern
+- Skill now has 12 steps (was 11)
+
 ## [0.3.0-alpha] — 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ After you run the skill, here's what happens:
 
 ![What I Did and updated score](images/report-actions.png)
 
-**4. Next steps** — clear actions: review, enable Copilot code review, and a ready-to-use prompt to create the PR.
+**4. Next steps** — clear actions: review, enable Copilot code review, add an AI-Ready badge, and a ready-to-use prompt to create the PR.
 
 ![What To Do Next](images/report-next-steps.png)
 
@@ -62,7 +62,7 @@ The skill starts by pulling context directly from GitHub — no questions asked:
 |------------------|-----|----------------|
 | Repo description, topics, languages | GitHub API | Knows what your project is without reading every file |
 | Community health score | GitHub API | Instantly knows which config files are missing |
-| Contributors | GitHub API | Populates CODEOWNERS automatically |
+| Contributors | GitHub API | Team size, contribution patterns |
 | Recent merged PRs | GitHub API | Understands what typical contributions look like |
 | **PR review comments** | GitHub API | **Turns your repeated review feedback into automated conventions** |
 | CI/CD workflows | GitHub Actions API | Knows your build/test pipeline |

--- a/skills/ai-ready/SKILL.md
+++ b/skills/ai-ready/SKILL.md
@@ -41,7 +41,7 @@ Use the GitHub MCP tools (if available) or `gh` CLI to pull rich context the use
 | Repo description, topics, visibility | `github-mcp-server-get_file_contents` on `/` or `gh repo view --json description,topics,isPrivate,primaryLanguage` | What this project is about, how it's categorized |
 | Language breakdown | `gh api repos/{owner}/{repo}/languages` (bash) | Accurate language percentages (better than guessing from files) |
 | Community health | `gh api repos/{owner}/{repo}/community/profile` (bash) | Which community files exist (CONTRIBUTING, CODE_OF_CONDUCT, license, issue templates) — GitHub already knows this |
-| Contributors | `gh api repos/{owner}/{repo}/contributors --jq '.[].login'` (bash) | Team size, who to put in CODEOWNERS |
+| Contributors | `gh api repos/{owner}/{repo}/contributors --jq '.[].login'` (bash) | Team size, contribution patterns |
 | Open issues | `github-mcp-server-list_issues` or `gh issue list` | Active problems, what the project cares about |
 | Recent merged PRs | `gh pr list --state merged --limit 10 --json title,body,files` (bash) | Contribution patterns — what files get touched together, what a typical PR looks like |
 | PR review comments | `github-mcp-server-pull_request_read` on recent PRs | **Repeated review feedback = conventions that should be in copilot-instructions.md** |
@@ -421,6 +421,7 @@ Let's see where you stand.
 
 1. Review the generated files and tweak anything you'd like
 2. Enable Copilot code review: **Settings → Copilot → Code review**
+3. Add an **AI-Ready badge** to your README — show the world your repo is AI-ready!
 
 Want me to create a branch and open a draft PR with these changes? You can review and edit before merging.
 ```
@@ -438,6 +439,34 @@ Rules for filling in the template:
 - The "What I Did" section should list every file that was created, suggested, or skipped
 - **Show an updated progress bar** after the "What I Did" section — recalculate the score counting all created files as now "Nailed It." This shows the user the improvement visually (e.g., going from 🟩🟩🟩🟩🟩🟨⬜⬜⬜⬜⬜ 45% → 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 100%)
 - The "What To Do Next" section should include only the bullet points that are relevant — e.g., if no files were created, skip "review generated files" and instead say something like "Your repo is already AI-ready — nice work!"
+
+---
+
+## Step 12 — Offer AI-Ready badge and topic
+
+After the report (and any draft PR), offer two optional promotional items. These are **opt-in only** — ask the user, never add them silently.
+
+### 12a. AI-Ready badge
+
+Ask the user if they'd like an AI-Ready badge added to their `README.md`. If yes, insert this badge at the top of the README, after any existing title or badge row:
+
+```markdown
+[![AI Ready](https://img.shields.io/badge/AI--Ready-yes-brightgreen?style=flat)](https://github.com/johnpapa/ai-ready)
+```
+
+Before inserting, check if the README already contains an `AI--Ready` badge — if so, skip it.
+
+The badge is a static Shields.io image with zero dependencies. It links back to the ai-ready plugin repo so others can discover it.
+
+### 12b. GitHub topic
+
+Ask the user if they'd like the `ai-ready` topic added to their repository:
+
+```bash
+gh repo edit --add-topic ai-ready
+```
+
+This makes the repo discoverable at `github.com/topics/ai-ready` alongside other AI-ready repos. Only offer this if the repo does not already have the `ai-ready` topic (check the topics fetched in Step 0b).
 
 ---
 


### PR DESCRIPTION
## What

Adds a new **Step 12** to the ai-ready skill that offers two optional promotional items after the AI-Readiness Report:

1. **Shields.io badge** — a small `AI-Ready: yes` badge for the user's README that links back to this plugin repo
2. **GitHub topic** — adds `ai-ready` topic to the repo, making it discoverable at `github.com/topics/ai-ready`

Both are **opt-in only** — the skill asks before adding, never does it silently.

### Example badge

```markdown
[![AI Ready](https://img.shields.io/badge/AI--Ready-yes-brightgreen?style=flat)](https://github.com/johnpapa/ai-ready)
```

## Why

- Gives users a fun way to show their repo is AI-ready
- Zero maintenance — Shields.io hosts the badge, no dependencies
- Non-intrusive — one line of markdown, same as license/CI badges
- Promotes the plugin organically through linked badges and the GitHub topic

## Also fixed

- Contributors row rationale changed from "who to put in CODEOWNERS" to "contribution patterns" — CODEOWNERS is a human reviewer workflow, not an AI-readiness concern

## Files changed

- `skills/ai-ready/SKILL.md` — new Step 12 + report template update + line 44 fix
- `README.md` — updated next-steps description + contributors row
- `CHANGELOG.md` — added Unreleased section