### PR TITLE
Update install instructions with marketplace and direct options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A Copilot CLI plugin that analyzes your repository and generates the configurati
 Install the plugin:
 
 ```bash
+# From the awesome-copilot marketplace (once available)
+copilot plugin install ai-ready@awesome-copilot
+
+# Or install directly from GitHub
 copilot plugin install johnpapa/ai-ready
 ```
 


### PR DESCRIPTION
Shows both install methods — marketplace (preferred, once the awesome-copilot PR lands) and direct GitHub install as fallback. Fixes the deprecation warning users see with `copilot plugin install johnpapa/ai-ready`.