### PR TITLE
feat: add optional HTML readiness reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **HTML readiness reports** (Step 11) — optional self-contained HTML report for sharing with stakeholders, triggered by user request
 - **AI-Ready badge** (Step 12) — opt-in Shields.io badge and `ai-ready` GitHub topic offered after the report, linking back to this plugin for discoverability
 - **Self-consistency rule** — generated files must follow the conventions established in the same PR's `copilot-instructions.md`, so Copilot code review finds zero issues
 - **Explicit asset list** — the 11 tracked assets are now enumerated with a scoring rubric (Nailed It = 1, Could Be Better = 0.5, Missing = 0)

--- a/skills/ai-ready/SKILL.md
+++ b/skills/ai-ready/SKILL.md
@@ -548,6 +548,24 @@ _Include this section only if the repo already has AI configuration (copilot-ins
 2. Enable Copilot code review: **Settings → Copilot → Code review**
 ```
 
+### HTML report (optional)
+
+*Why?*: Terminal reports are great for the developer running the skill. But when you need to share results with a manager, post to a wiki, or attach to an email — you need something visual.
+
+Generate the HTML report only when the user asks for it — phrases like "generate a report I can share" or "make an HTML report". The terminal output is always the default.
+
+When requested, create a single self-contained `ai-ready-report.html` in the repo root. All CSS inline, no external dependencies — one file you can open in any browser or drop into an email.
+
+Include these sections:
+1. **Header** — repo name, score, maturity percentage, generation date
+2. **Progress bar** — visual bar with green (nailed), amber (could be better), and gray (missing) segments
+3. **Tech profile** — languages, frameworks, test runner, build command
+4. **Asset status table** — all tracked assets with status icons (✅ Nailed It, 💡 Could Be Better, ⭕ Missing) and one-line details
+5. **What was generated** — files created or suggested in this run
+6. **Recommendations** — actionable next steps for remaining gaps
+
+Use a clean design with green/amber/gray status colors, system fonts, and a responsive layout. Keep it simple — this is a summary, not a dashboard.
+
 After displaying the report, handle the badge, topic, and PR in this order:
 
 ### 11a. Add AI-Ready badge


### PR DESCRIPTION
Adds the ability to generate a visual HTML report for sharing.

**What it does:**
- Generates self-contained `ai-ready-report.html` when user requests it
- Includes score, progress bar, tech profile, asset status, and recommendations
- Clean, modern design with responsive layout
- Only generated on explicit request — terminal report remains the default

**Trigger phrases:** "generate an HTML report", "create a visual report", "make a report I can share"

**Changes:**
- New 'HTML report' subsection added to Step 11 in SKILL.md
- CHANGELOG.md updated