### PR TITLE
fix: add missing changelog for Do No Harm, add changelog to PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@ cp skills/ai-ready/SKILL.md ~/.copilot/skills/ai-ready/SKILL.md
 - [ ] SKILL.md frontmatter includes `name` and `description`
 - [ ] All YAML files are valid syntax
 - [ ] Tested the skill on at least one repo (specify which below)
+- [ ] Updated `CHANGELOG.md` with what changed and why
 - [ ] Updated `AGENTS.md` if repo structure changed
 - [ ] Updated `README.md` if user-facing behavior changed
 - [ ] Updated `docs/how-it-works.md` if the 3-mechanism or 9-asset model changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ All notable changes to this project will be documented in this file.
   - `training-repos.md` — validation repo list
 - "Tested Against" section in README linking to training repos
 - `references/*` entry in maintenance matrix
+- **"Do No Harm" principle** — safety rules: never create duplicates, never push to main/master without permission, never overwrite files, never delete without approval
+- **Duplicate file prevention** — Step 1d and Step 4 check ALL known locations for `copilot-setup-steps.yml` before creating
+- `Updated CHANGELOG.md` checkbox added to PR template checklist
+
+### Fixed
+
+- **Duplicate `copilot-setup-steps.yml` creation** — previous runs could create a second copy if the file existed at a legacy location
 
 ## [Unreleased]
 


### PR DESCRIPTION
## Description

PR #19 added Do No Harm rules but missed the CHANGELOG.md update. This fixes the gap and adds a safeguard.

## Changes

- **CHANGELOG.md** — added v1.0.1 entry for Do No Harm rules and duplicate prevention
- **SKILL.md** — bumped `metadata.version` to `1.0.1`
- **PR template** — added `Updated CHANGELOG.md` checkbox to the checklist

## Why the PR template change matters

The maintenance matrix already says _"When SKILL.md changes → also update CHANGELOG.md"_ — but matrices are advisory. A PR checklist checkbox is a **gate** that reviewers (human or AI) can enforce. This makes it much harder to forget.