### PR TITLE
fix: add paths-ignore to CI and fix README numbering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,24 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "images/**"
+      - "examples/**"
+      - "LICENSE"
+      - "README.md"
+      - "CHANGELOG.md"
+      - "SECURITY.md"
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "images/**"
+      - "examples/**"
+      - "LICENSE"
+      - "README.md"
+      - "CHANGELOG.md"
+      - "SECURITY.md"
 
 jobs:
   validate:

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This skill has been validated against a diverse set of repos — courses, applic
 1. Fork this repo and create a branch
 2. Make your changes (skills or docs)
 3. Test locally: copy `skills/ai-ready/SKILL.md` to `~/.copilot/skills/ai-ready/SKILL.md`, start `copilot`, then say *"make this repo ai-ready"*
-5. Open a PR
+4. Open a PR
 
 See [AGENTS.md](AGENTS.md) for the full contributor guide.
 


### PR DESCRIPTION
## Description

Two minor fixes found during ai-ready audit of this repo.

## Changes

- `.github/workflows/ci.yml` — added `paths-ignore` so CI skips runs for pure docs/images/examples changes (README, CHANGELOG, SECURITY, LICENSE, docs/, images/, examples/). SKILL.md and .github/ YAML changes still trigger validation.
- `README.md` — fixed Contributing section numbering (step 3 → 5 → now 3 → 4)

## How to Test

```bash
# Verify CI still triggers on SKILL.md changes
# Verify CI skips on README-only changes
```

## Checklist

- [x] SKILL.md frontmatter includes `name` and `description`
- [x] All YAML files are valid syntax
- [x] Updated `CHANGELOG.md` — N/A (trivial fix, no user-facing behavior change)
- [ ] Updated `AGENTS.md` if repo structure changed — N/A
- [ ] Updated `README.md` if user-facing behavior changed — fixed numbering only
- [ ] Updated `docs/how-it-works.md` — N/A