### PR TITLE
Extend the never-push-to-main rule to cover PR follow-through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - **Documentation sync rule** — when skill behavior changes, update related docs to match repo standards and maintenance matrix.
 - **PR conflict handling rule** — when preparing PRs, sync with the target branch and attempt conflict resolution; if conflicts remain, ask the user how to proceed.
+- **PR follow-through rule** — the never-push-to-main rule now covers what happens after a PR is opened too: once CI passes, merge it (if low-risk and well-tested) or ask the user, and always report the outcome. An opened PR left unattended, with no report back, is no longer acceptable.
 
 ## [1.2.0] — 2026-07-17
 

--- a/skills/ai-ready/SKILL.md
+++ b/skills/ai-ready/SKILL.md
@@ -220,6 +220,7 @@ This skill's first obligation is to leave the repo in a **better state than it f
 
 - **NEVER create duplicates** — before creating any file, check ALL known locations (canonical, legacy, and root). If a file exists anywhere, do not create another copy. Consolidate instead.
 - **NEVER push directly to main/master** — always create a feature branch and open a PR for review. The only exception is if the user explicitly asks to commit to the default branch.
+- **NEVER leave an opened PR unattended** — once a PR is open and CI passes, either merge it (small, well-tested, no ambiguous judgment calls) or ask the user which way to go; report the outcome either way. Opening a PR and going quiet is not acceptable. If CI is red or still pending, don't merge — fix it, wait, or report the blocker instead.
 - **NEVER overwrite existing files** — only create missing assets. Flag drift for user review.
 - **NEVER delete files without user approval** — if consolidating duplicates or removing stale files, include the deletion in the PR for review.
 


### PR DESCRIPTION
## Description

The existing "Do No Harm" rule only covers not pushing directly to main — it stops at "open a PR." That leaves a gap: nothing said what should happen once a PR is actually open. Adds a second rule covering the rest of the lifecycle: once CI passes, merge (if low-risk/well-tested) or ask the user, and always report the outcome — never leave an opened PR unattended with no report back.

## Changes

- `skills/ai-ready/SKILL.md` — added a PR follow-through bullet right after the existing never-push-to-main rule in "Do No Harm"
- `CHANGELOG.md` — logged under `[Unreleased] → Changed`, matching the style of the two rule entries already there

## How to Test

```bash
copilot plugin install johnpapa/ai-ready
# Then start copilot and say: "make this repo ai-ready"
```
Generated AGENTS.md files for target repos should now carry the fuller PR-lifecycle rule, not just the "don't push to main" half.

## Checklist

- [x] SKILL.md frontmatter includes `name` and `description` (unchanged, still valid — verified locally)
- [x] All YAML files are valid syntax (no YAML touched)
- [ ] Tested the skill on at least one repo — this PR only edits the rule text the skill embeds; the mechanism it exercises (`copilot plugin install`) needs your own machine
- [x] Updated `CHANGELOG.md` with what changed and why
- [ ] Updated `AGENTS.md` if repo structure changed — not applicable, no structure change
- [ ] Updated `README.md` if user-facing behavior changed — not applicable, this only strengthens an existing rule's wording
- [ ] Updated `docs/how-it-works.md` if the 3-mechanism or 12-asset model changed — not applicable

## Tested On

| Repo | Type | Result |
|------|------|--------|
| — | — | Rule-text change only; not independently invoked against a target repo in this PR |

Assisted by [ai-ready](https://github.com/johnpapa/ai-ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8XirhXqSmMN7qBP6hmVG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8XirhXqSmMN7qBP6hmVG1)_