### PR TITLE
Require asking before every merge; squash + delete branch after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - **Documentation sync rule** — when skill behavior changes, update related docs to match repo standards and maintenance matrix.
 - **PR conflict handling rule** — when preparing PRs, sync with the target branch and attempt conflict resolution; if conflicts remain, ask the user how to proceed.
 - **PR follow-through rule** — the never-push-to-main rule now covers what happens after a PR is opened too: once CI passes, merge it (if low-risk and well-tested) or ask the user, and always report the outcome. An opened PR left unattended, with no report back, is no longer acceptable.
+- **PR follow-through rule, revised** — merging is never the skill's own call, even for a low-risk change: always ask the user first. When they say yes, merge with squash and delete the branch afterward.
 
 ## [1.2.0] — 2026-07-17
 

--- a/skills/ai-ready/SKILL.md
+++ b/skills/ai-ready/SKILL.md
@@ -220,7 +220,8 @@ This skill's first obligation is to leave the repo in a **better state than it f
 
 - **NEVER create duplicates** — before creating any file, check ALL known locations (canonical, legacy, and root). If a file exists anywhere, do not create another copy. Consolidate instead.
 - **NEVER push directly to main/master** — always create a feature branch and open a PR for review. The only exception is if the user explicitly asks to commit to the default branch.
-- **NEVER leave an opened PR unattended** — once a PR is open and CI passes, either merge it (small, well-tested, no ambiguous judgment calls) or ask the user which way to go; report the outcome either way. Opening a PR and going quiet is not acceptable. If CI is red or still pending, don't merge — fix it, wait, or report the blocker instead.
+- **NEVER leave an opened PR unattended** — once a PR is open and CI passes, ask the user before merging, every time; never merge on the skill's own judgment, regardless of how small or low-risk the change looks. If CI is red or still pending, don't merge — fix it, wait, or report the blocker instead. Either way, report the outcome; opening a PR and going quiet is not acceptable.
+- **When the user says yes, merge with squash and delete the branch** — both local and remote. Don't leave merged branches lying around.
 - **NEVER overwrite existing files** — only create missing assets. Flag drift for user review.
 - **NEVER delete files without user approval** — if consolidating duplicates or removing stale files, include the deletion in the PR for review.
 


### PR DESCRIPTION
## Description

Revises the PR follow-through rule from #30 (merged minutes ago): merging on the skill's own judgment for a "low-risk" change turned out not to be the actual preference. Asking before merging is now unconditional — no size/risk exception. Also codifies merge method (squash) and post-merge cleanup (delete the branch).

## Changes

- `skills/ai-ready/SKILL.md` — "Do No Harm" rule now requires asking before every merge, and adds a squash + delete-branch rule
- `CHANGELOG.md` — logged under `[Unreleased] → Changed`

## How to Test

```bash
copilot plugin install johnpapa/ai-ready
# Then start copilot and say: "make this repo ai-ready"
```

## Checklist

- [x] SKILL.md frontmatter includes `name` and `description` (unchanged, still valid)
- [x] All YAML files are valid syntax (no YAML touched)
- [ ] Tested the skill on at least one repo — rule-text change only
- [x] Updated `CHANGELOG.md` with what changed and why
- [ ] Updated `AGENTS.md` if repo structure changed — not applicable
- [ ] Updated `README.md` if user-facing behavior changed — not applicable
- [ ] Updated `docs/how-it-works.md` — not applicable

## Tested On

| Repo | Type | Result |
|------|------|--------|
| — | — | Rule-text change only |

Assisted by [ai-ready](https://github.com/johnpapa/ai-ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8XirhXqSmMN7qBP6hmVG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8XirhXqSmMN7qBP6hmVG1)_