### PR TITLE
Add squash-merge and delete-branch to the PR follow-through rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - **Documentation sync rule** — when skill behavior changes, update related docs to match repo standards and maintenance matrix.
 - **PR conflict handling rule** — when preparing PRs, sync with the target branch and attempt conflict resolution; if conflicts remain, ask the user how to proceed.
 - **PR follow-through rule** — the never-push-to-main rule now covers what happens after a PR is opened too: once CI passes, merge it (if low-risk and well-tested) or ask the user, and always report the outcome. An opened PR left unattended, with no report back, is no longer acceptable.
+- **Squash + delete-branch rule** — whenever a merge happens, use squash and delete the branch afterward (local and remote).
 
 ## [1.2.0] — 2026-07-17
 

--- a/skills/ai-ready/SKILL.md
+++ b/skills/ai-ready/SKILL.md
@@ -221,6 +221,7 @@ This skill's first obligation is to leave the repo in a **better state than it f
 - **NEVER create duplicates** — before creating any file, check ALL known locations (canonical, legacy, and root). If a file exists anywhere, do not create another copy. Consolidate instead.
 - **NEVER push directly to main/master** — always create a feature branch and open a PR for review. The only exception is if the user explicitly asks to commit to the default branch.
 - **NEVER leave an opened PR unattended** — once a PR is open and CI passes, either merge it (small, well-tested, no ambiguous judgment calls) or ask the user which way to go; report the outcome either way. Opening a PR and going quiet is not acceptable. If CI is red or still pending, don't merge — fix it, wait, or report the blocker instead.
+- **Whenever a merge happens, use squash and delete the branch afterward** — both local and remote. Don't leave merged branches lying around.
 - **NEVER overwrite existing files** — only create missing assets. Flag drift for user review.
 - **NEVER delete files without user approval** — if consolidating duplicates or removing stale files, include the deletion in the PR for review.
 


### PR DESCRIPTION
## Description

Small addition to the PR follow-through rule from #30: whenever a merge happens (skill-initiated for low-risk changes, or after the user says yes), use squash and delete the source branch afterward.

## Changes

- `skills/ai-ready/SKILL.md` — one new bullet in "Do No Harm"
- `CHANGELOG.md` — logged under `[Unreleased] → Changed`

## Checklist

- [x] SKILL.md frontmatter unchanged, still valid
- [x] No YAML touched
- [x] Updated `CHANGELOG.md`
- [ ] Not applicable: AGENTS.md/README/docs (no structure or user-facing behavior change)

Assisted by [ai-ready](https://github.com/johnpapa/ai-ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8XirhXqSmMN7qBP6hmVG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8XirhXqSmMN7qBP6hmVG1)_