### PR TITLE
Release v1.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ai-ready",
       "source": "./",
       "description": "Analyze any repository and generate AI-ready configuration — AGENTS.md, copilot-instructions.md, skills, CI workflows, issue templates.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "John Papa",
         "url": "https://github.com/johnpapa"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-ready",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Analyze any repository and generate AI-ready configuration — AGENTS.md, copilot-instructions.md, skills, CI workflows, issue templates.",
   "author": {
     "name": "John Papa",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-ready",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Analyze any repository and generate AI-ready configuration — AGENTS.md, copilot-instructions.md, skills, CI workflows, issue templates.",
   "skills": "./skills/"
 }

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-ready",
   "description": "Analyze any repository and generate AI-ready configuration — AGENTS.md, copilot-instructions.md, skills, CI workflows, issue templates.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "John Papa",
     "url": "https://github.com/johnpapa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.3.0] — 2026-09-05
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ plugin from it.
 `~/.agents/skills/` is the vendor-neutral [Agent Skills](https://agentskills.io) directory that Codex and Cursor
 both read, so the last row works for most tools.
 
-If a marketplace mirrors this skill, it should point to a release tag such as `v1.2.0`, not a raw commit SHA.
+If a marketplace mirrors this skill, it should point to a release tag such as `v1.3.0`, not a raw commit SHA.
 
 ### Then type
 
@@ -88,7 +88,7 @@ The skill is safe to re-run. On the first run, it creates missing assets. On sub
 
 The marketplace entry is pointing at a commit SHA. Plugin installs clone with `git clone --branch <ref>`, which
 only accepts a branch or tag, so a raw SHA always fails. The registry entry needs to use a release tag such as
-`v1.2.0`. See [#26](https://github.com/johnpapa/ai-ready/issues/26).
+`v1.3.0`. See [#26](https://github.com/johnpapa/ai-ready/issues/26).
 
 Installing directly from this repo (`copilot plugin install johnpapa/ai-ready`) avoids the problem entirely.
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "ai-ready",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Analyze any repository and generate AI-ready configuration — AGENTS.md, copilot-instructions.md, skills, CI workflows, issue templates.",
   "author": {
     "name": "John Papa",

--- a/skills/ai-ready/SKILL.md
+++ b/skills/ai-ready/SKILL.md
@@ -2,7 +2,7 @@
 name: ai-ready
 license: MIT
 metadata:
-  version: "1.2.0"
+  version: "1.3.0"
 description: "**ANALYSIS SKILL** — Analyze any repository and generate AI-ready configuration — AGENTS.md, copilot-instructions.md, skills, CI workflows, issue templates. WHEN: \"make this repo ai-ready\", \"set up AI config\", \"add copilot instructions\", \"prepare this repo for AI contributions\", \"generate AGENTS.md\". INVOKES: glob, grep, view, create, edit for repo analysis and file generation. FOR SINGLE OPERATIONS: use create/edit directly for individual config files."
 ---
 


### PR DESCRIPTION
Cuts a release containing the multi-tool packaging and corrected install docs from #33.

## Why now

`github/awesome-copilot` pins `ai-ready` to the `v1.1.0` tag. That tag — and `v1.2.0` — both predate the plugin-manifest version fix from #26, so anyone installing from the registry still gets the drifted metadata. There is no existing tag that contains the fix.

This bumps `1.2.0` → `1.3.0` across `SKILL.md` `metadata.version` and all five plugin manifests, which CI enforces must stay in lockstep.

## Follow-up

Once tagged, the `awesome-copilot` entry gets repointed to `v1.3.0`.

---

Assisted by [ai-ready](https://github.com/johnpapa/ai-ready)