### PR TITLE
Fix Copilot install docs and unblock docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,6 @@ name: CI
 
 on:
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "images/**"
-      - "examples/**"
-      - "LICENSE"
-      - "README.md"
-      - "CHANGELOG.md"
-      - "SECURITY.md"
   push:
     branches: [main]
     paths-ignore:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- **Copilot install now uses the marketplace** — documented
+  `copilot plugin install ai-ready@awesome-copilot` instead of installing straight from the repo. Copilot CLI
+  reports direct repo, URL, and local-path installs as deprecated.
+
 ## [1.3.0] — 2026-09-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable changes to this project will be documented in this file.
   `copilot plugin install ai-ready@awesome-copilot` instead of installing straight from the repo. Copilot CLI
   reports direct repo, URL, and local-path installs as deprecated.
 
+### Fixed
+
+- **Docs-only PRs could never merge** — `validate` is a required status check, but the CI workflow's
+  `pull_request` trigger used `paths-ignore` for markdown. A PR touching only docs never ran the check, so
+  branch protection blocked it forever. Removed `paths-ignore` from the `pull_request` trigger; the job takes
+  about ten seconds.
+
 ## [1.3.0] — 2026-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Prefer your tool's own plugin system? Each of these installs the same skill.
 
 | Tool | Install |
 |---|---|
-| **GitHub Copilot CLI** | `copilot plugin install johnpapa/ai-ready` |
+| **GitHub Copilot CLI** | `copilot plugin install ai-ready@awesome-copilot` |
 | **Claude Code** | `/plugin marketplace add johnpapa/ai-ready`<br>`/plugin install ai-ready@johnpapa-ai-ready` |
 | **OpenAI Codex** | `codex plugin marketplace add johnpapa/ai-ready`<br>`codex plugin add ai-ready@johnpapa-ai-ready` |
 | **Cursor** | Copy `skills/ai-ready/` into `~/.cursor/skills/ai-ready/` |
@@ -34,6 +34,9 @@ Prefer your tool's own plugin system? Each of these installs the same skill.
 
 Claude and Codex each need **two** commands — the first registers the marketplace, the second installs the
 plugin from it.
+
+Copilot CLI installs from the built-in `awesome-copilot` marketplace. Installing straight from a repo
+(`copilot plugin install johnpapa/ai-ready`) still works but is deprecated, so prefer the marketplace form.
 
 `~/.agents/skills/` is the vendor-neutral [Agent Skills](https://agentskills.io) directory that Codex and Cursor
 both read, so the last row works for most tools.


### PR DESCRIPTION
Two fixes found while verifying the install instructions.

## 1. Copilot install path is deprecated

Copilot CLI now warns on direct repo installs — caught by running the command the README documents:

```
$ copilot plugin install johnpapa/ai-ready
Plugin "ai-ready" installed successfully. Installed 1 skill.

Warning: Direct plugin installs (repos, URLs, local paths) are deprecated.
Only plugin@marketplace installs will be supported in a future release.
```

`ai-ready` ships in the `awesome-copilot` marketplace that Copilot CLI bundles by default, so the marketplace form works today and will keep working:

```bash
copilot plugin install ai-ready@awesome-copilot
```

## 2. Docs-only PRs could never merge

`validate` is a required status check, but the workflow's `pull_request` trigger used `paths-ignore` for markdown. A PR touching only docs never produced the check, so branch protection blocked it with no way to satisfy the requirement short of `--admin`.

This PR hit exactly that — it was unmergeable until the workflow was fixed:

```
X Pull request johnpapa/ai-ready#35 is not mergeable: the base branch policy prohibits the merge.
```

Removed `paths-ignore` from the `pull_request` trigger. The job runs in about 8 seconds. `push` keeps its filters since nothing is gated on that result.

The fix is self-demonstrating: `validate` now runs and passes on this PR.

---

Assisted by [ai-ready](https://github.com/johnpapa/ai-ready)